### PR TITLE
Investigate docker server workflow failure

### DIFF
--- a/.github/workflows/docker-publish-server.yml
+++ b/.github/workflows/docker-publish-server.yml
@@ -64,6 +64,12 @@ jobs:
           cosign-release: 'v2.2.4'
 
 
+      # Enable QEMU emulation for multi-arch builds
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish-toolbox.yml
+++ b/.github/workflows/docker-publish-toolbox.yml
@@ -64,6 +64,12 @@ jobs:
           cosign-release: 'v2.2.4'
 
 
+      # Enable QEMU emulation for multi-arch builds
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ MAIN_FILE=cmd/server/main.go
 GO_FILES=$(shell find . -name '*.go' -type f -not -path "./vendor/*")
 PROTO_FILES=$(shell find . -name '*.proto' -type f -not -path "./vendor/*")
 
+tools:
+	@ echo "Installing buf CLI..."
+	@ go install github.com/bufbuild/buf/cmd/buf@v1.34.0
+
 bin: gen $(GO_FILES)
 	GOOS=$(OS) GOARCH=$(ARCH) go build -v -o $(OUTPUT_DIR)/$(OUTPUT_NAME) $(MAIN_FILE)
 


### PR DESCRIPTION
Add QEMU setup for multi-arch Docker builds and a missing `make tools` target to fix GitHub Actions workflow failures.

The "Docker / Server" workflow was failing because the Dockerfile expected a `make tools` target that was not present in the `Makefile`. Additionally, multi-architecture builds often fail without explicit QEMU setup on GitHub-hosted runners, which was a likely contributing factor to the job's instability.

---
<a href="https://cursor.com/background-agent?bcId=bc-73ece974-a0b1-48c8-88a6-18f96b98d7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73ece974-a0b1-48c8-88a6-18f96b98d7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

